### PR TITLE
Feature - create consistent format for type-check and lint outputs

### DIFF
--- a/scripts/linting/eslint.config.js
+++ b/scripts/linting/eslint.config.js
@@ -55,6 +55,7 @@ module.exports = (inputParams = {}) => {
       'no-nested-ternary': 'off',
       'prefer-destructuring': 'off',
       'arrow-body-style': 'off',
+      'max-classes-per-file': 'off',
       'sort-imports': ['error', { ignoreCase: true, ignoreDeclarationSort: true }],
       'jsx-quotes': ['error', 'prefer-single'],
       'react/self-closing-comp': ['error', { component: true, html: true }],

--- a/scripts/linting/lint.js
+++ b/scripts/linting/lint.js
@@ -80,19 +80,23 @@ class GitHubAnnotationsFormatter {
 class PrettyFormatter {
   // eslint-disable-next-line class-methods-use-this
   format(eslintResults) {
-    const messages = [];
+    const messageGroups = {};
     eslintResults.filter((result) => result.errorCount > 0 || result.warningCount > 0).forEach((result) => {
+      const messages = [];
+      const filePath = path.relative(process.cwd(), result.filePath);
       result.messages.filter((message) => message.severity > 0).forEach((message) => {
         messages.push({
-          filePath: path.relative(process.cwd(), result.filePath),
-          start_line: message.line,
-          start_column: message.column,
-          message: `[${message.ruleId || 'global'}] ${message.message}`,
+          filePath: filePath,
+          line: message.line,
+          column: message.column,
+          rule: message.ruleId || 'global',
+          message: message.message,
           severity: message.severity,
         });
       });
+      messageGroups[filePath] = messages;
     });
-    console.log(messages);
+    console.log(messageGroups);
     // return JSON.stringify(annotations);
     return '';
   }

--- a/scripts/linting/lint.js
+++ b/scripts/linting/lint.js
@@ -43,8 +43,7 @@ module.exports = async (inputParams = {}) => {
     await ESLint.outputFixes(results);
   }
 
-  const stylishFormatter = await cli.loadFormatter('stylish');
-  console.log(stylishFormatter.format(results));
+  console.log(new PrettyFormatter().format(results));
   if (params.outputFile) {
     const fileFormat = params.outputFileFormat || 'json';
     const formatter = fileFormat === 'annotations' ? new GitHubAnnotationsFormatter() : await cli.loadFormatter(fileFormat);
@@ -75,5 +74,26 @@ class GitHubAnnotationsFormatter {
       });
     });
     return JSON.stringify(annotations);
+  }
+}
+
+class PrettyFormatter {
+  // eslint-disable-next-line class-methods-use-this
+  format(eslintResults) {
+    const messages = [];
+    eslintResults.filter((result) => result.errorCount > 0 || result.warningCount > 0).forEach((result) => {
+      result.messages.filter((message) => message.severity > 0).forEach((message) => {
+        messages.push({
+          filePath: path.relative(process.cwd(), result.filePath),
+          start_line: message.line,
+          start_column: message.column,
+          message: `[${message.ruleId || 'global'}] ${message.message}`,
+          severity: message.severity,
+        });
+      });
+    });
+    console.log(messages);
+    // return JSON.stringify(annotations);
+    return '';
   }
 }

--- a/scripts/typing/ts.config.js
+++ b/scripts/typing/ts.config.js
@@ -27,6 +27,7 @@ module.exports = (inputParams = {}) => {
       noFallthroughCasesInSwitch: false,
       allowSyntheticDefaultImports: true,
       esModuleInterop: true,
+      resolveJsonModule: true,
     },
   };
 };

--- a/scripts/typing/type.js
+++ b/scripts/typing/type.js
@@ -103,8 +103,8 @@ class PrettyFormatter {
       if (!(message.filePath in accumulatedValue)) {
         accumulatedValue[message.filePath] = [];
       }
-      const group = accumulatedValue[message.filePath];
-      group.push(message);
+      const messageGroup = accumulatedValue[message.filePath];
+      messageGroup.push(message);
       return accumulatedValue;
     }, {});
     const output = Object.keys(groupedMessages).reduce((accumulatedValue, groupFilename) => {

--- a/scripts/typing/type.js
+++ b/scripts/typing/type.js
@@ -99,7 +99,7 @@ class PrettyFormatter {
     const fileMessageMap = [];
     typingDiagnostics.forEach((diagnostic) => {
       const message = typescript.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
-      const severity = diagnostic.category === 1 ? 'failure' : 'warning';
+      const severity = diagnostic.category === 1 ? 'error' : 'warning';
       let filePath = '(unknown)';
       let line = 0;
       let column = 0;

--- a/scripts/typing/type.js
+++ b/scripts/typing/type.js
@@ -116,7 +116,7 @@ class PrettyFormatter {
     });
     let totalErrorCount = 0;
     let totalWarningCount = 0;
-    const output = Object.keys(fileMessageMap).reduce((accumulatedValue, filePath) => {
+    let output = Object.keys(fileMessageMap).reduce((accumulatedValue, filePath) => {
       const fileMessages = fileMessageMap[filePath].reduce((innerAccumulatedValue, message) => {
         // const color = message.severity === 'error' ? chalk.red : chalk.yellow;
         const location = chalk.grey(`${message.filePath}:${message.line}:${message.column}`);
@@ -129,7 +129,7 @@ class PrettyFormatter {
       totalWarningCount += warningCount;
       return `${accumulatedValue}\n${this.getSummary(errorCount, warningCount)} in ${filePath}\n${fileMessages.join('\n')}\n`;
     }, '');
-    const outcome = totalErrorCount || totalWarningCount ? `Failed due to ${this.getSummary(totalErrorCount, totalWarningCount)}.` : 'Succeeded.';
-    return `${output}\n${outcome}`;
+    output += (totalErrorCount || totalWarningCount) ? `\nFailed due to ${this.getSummary(totalErrorCount, totalWarningCount)}.` : chalk.green('Passed.');
+    return output;
   }
 }


### PR DESCRIPTION
now looks like this:

<img width="1566" alt="Screen Shot 2021-01-06 at 17 01 18" src="https://user-images.githubusercontent.com/3192370/103797829-dfee5680-5040-11eb-9546-dadc6ac3f799.png">

<img width="1353" alt="Screen Shot 2021-01-07 at 17 40 15" src="https://user-images.githubusercontent.com/3192370/103925422-725d2b80-510f-11eb-8d02-0483f2a84413.png">

which means for every error you can click the path and be taken straight to the problem