### PR TITLE
Fix: stop showing overlay on errors for start-react-app

### DIFF
--- a/scripts/react-app/build.js
+++ b/scripts/react-app/build.js
@@ -59,6 +59,7 @@ module.exports = (inputParams = {}) => {
         logging: 'info',
       },
       open: false,
+      overlay: false,
       static: {
         directory: mergedConfig.output.publicPath,
         watch: {


### PR DESCRIPTION
<!--- Title format: [Feature | Fix | Task#]: <summary of your changes> -->

## Description

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
<!-- - [ ] I have updated the documentation accordingly -->
<!-- - [ ] My changes have tests around them -->
